### PR TITLE
Handle ConnectionError and stderr logging

### DIFF
--- a/djiffy/importer.py
+++ b/djiffy/importer.py
@@ -49,7 +49,7 @@ class ManifestImporter(object):
             try:
                 manifest = IIIFPresentation.from_file_or_url(path)
             except IIIFException as err:
-                self.stderr.write(str(err))
+                self.error_msg(str(err))
                 continue
 
             if manifest.type == 'sc:Collection':

--- a/djiffy/models.py
+++ b/djiffy/models.py
@@ -311,21 +311,24 @@ class IIIFPresentation(AttrMap):
         :raises: :class:`IIIFException` if URL is not retrieved successfully,
             if the response is not JSON content, or if the JSON cannot be parsed.
         '''
-        response = get_iiif_url(uri)
-        if response.status_code == requests.codes.ok:
-            try:
-                return cls(response.json())
-            except json.decoder.JSONDecodeError as err:
-                # if json fails, two possibilities:
-                # - we didn't actually get json (e.g. redirect for auth)
-                if 'application/json' not in response.headers['content-type']:
-                    raise IIIFException('No JSON found at %s' % uri)
-                # - there is something wrong with the json
-                raise IIIFException('Error parsing JSON for %s: %s' %
-                    (uri, err))
-
-        raise IIIFException('Error retrieving manifest at %s: %s %s' %
-            (uri, response.status_code, response.reason))
+        try:
+            response = get_iiif_url(uri)
+            if response.status_code == requests.codes.ok:
+                try:
+                    return cls(response.json())
+                except json.decoder.JSONDecodeError as err:
+                    # if json fails, two possibilities:
+                    # - we didn't actually get json (e.g. redirect for auth)
+                    if 'application/json' not in response.headers['content-type']:
+                        raise IIIFException('No JSON found at %s' % uri)
+                    # - there is something wrong with the json
+                    raise IIIFException('Error parsing JSON for %s: %s' %
+                        (uri, err))
+            raise IIIFException('Error retrieving manifest at %s: %s %s' %
+                (uri, response.status_code, response.reason))
+        except ConnectionError:
+            # could not reach URL to get a status code in the first place
+            raise IIIFException('Error connecting to manifest at %s' % uri)
 
     @classmethod
     def is_url(cls, url):


### PR DESCRIPTION
This should handle the errors in the way that we want:

- Adds an additional condition for raising a `IIIFException` in `from_url` (`ConnectionError` on the GET req)
- Uses the `error_msg` function to avoid errors trying to log to stderr

Basically this is the "alternative" I mentioned here: https://github.com/Princeton-CDH/geniza/issues/605#issuecomment-1041893684

I think it makes sense to just leave behavior in djiffy essentially the same as before with additional error handling. It will silently fail if using the importer on individual records when stderr isn't defined, but I think we can take care of that with things like form validation in the admin on PGP.