### PR TITLE
Add attribution to extra_data in manifest import

### DIFF
--- a/djiffy/fixtures/chto-manifest.json
+++ b/djiffy/fixtures/chto-manifest.json
@@ -895,5 +895,6 @@
     "format": "application/ld+json"
   },
   "license": "http://rightsstatements.org/vocab/NKC/1.0/",
-  "logo": "https://example.com/logo.png"
+  "logo": "https://example.com/logo.png",
+  "attribution": "Created by a person"
 }

--- a/djiffy/importer.py
+++ b/djiffy/importer.py
@@ -173,8 +173,8 @@ class ManifestImporter(object):
                     response = get_iiif_url(url)
                     db_manifest.extra_data[url] = response.json()
 
-        # also check for logo and license and add to extra data
-        for field in ['logo', 'license']:
+        # also check for logo, license, and attribution and add to extra data
+        for field in ['logo', 'license', 'attribution']:
             if hasattr(manifest, field):
                 db_manifest.extra_data[field] = getattr(manifest, field)
 

--- a/djiffy/models.py
+++ b/djiffy/models.py
@@ -89,6 +89,11 @@ class Manifest(models.Model):
         return self.extra_data.get('logo', None)
 
     @property
+    def attribution(self):
+        '''manifest attribution, if there is one'''
+        return self.extra_data.get('attribution', None)
+
+    @property
     def license(self):
         '''manifest license, if there is one'''
         return self.extra_data.get('license', None)

--- a/djiffy/tests.py
+++ b/djiffy/tests.py
@@ -74,6 +74,13 @@ class TestManifest(TestCase):
         book.extra_data['license'] = 'http://rightsstatements.org/vocab/InC/1.0/'
         assert book.license == book.extra_data['license']
 
+    def test_attribution(self):
+        book = Manifest(short_id='bk123')
+        assert book.attribution is None
+
+        book.extra_data['attribution'] = 'Created by a person'
+        assert book.attribution == book.extra_data['attribution']
+
     def test_rights_statement_id(self):
         book = Manifest(short_id='bk123')
         assert book.rights_statement_id is None
@@ -481,9 +488,10 @@ class TestManifestImporter(TestCase):
         assert manif.extra_data[pres.seeAlso.id] == mock_extra_data
         assert mock_getiiifurl.called_with(pres.seeAlso.id)
         assert mock_getiiifurl.return_value.json.called_with()
-        # license & logo available
+        # license, logo, & attribution available
         assert manif.license == "http://rightsstatements.org/vocab/NKC/1.0/"
         assert manif.logo == "https://example.com/logo.png"
+        assert manif.attribution == "Created by a person"
 
         assert len(manif.canvases.all()) == len(pres.sequences[0].canvases)
         assert manif.thumbnail.iiif_image_id == \
@@ -539,7 +547,7 @@ class TestManifestImporter(TestCase):
         manif.delete()
         del pres.seeAlso
         manif = self.importer.import_manifest(pres, self.test_manifest)
-        assert set(manif.extra_data.keys()) == set(['logo', 'license'])
+        assert set(manif.extra_data.keys()) == set(['logo', 'license', 'attribution'])
 
         # unsupported type won't import
         pres.id = 'http://some.other/uri'


### PR DESCRIPTION
During https://github.com/Princeton-CDH/geniza/issues/591, I realized there was no way to get the attribution directly from a locally-cached manifest, so this djiffy PR adds it to `extra_data` when available.