### PR TITLE
Relax django-autocomplete-light dependency (#21)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
   "django>=3.2",
   "requests",
   "piffle>=0.6",
-  "django-autocomplete-light<=3.9.7",
+  "django-autocomplete-light>=3.9.7",
   "rdflib>=7.0",
 ]
 


### PR DESCRIPTION
**Associated Issue(s):** #21

### Changes in this PR

- Set django-autocomplete-light 3.9.7 as a min version, rather than a max

### Notes

- Tested on geniza with DAL 3.11.0
- Geniza will require DAL 3.11.0+ moving forward in order to upgrade Django